### PR TITLE
feat: add additional event aggregation for match telemetry

### DIFF
--- a/src/DTOs/Concerns/HasEnvironmentInteractionEvents.php
+++ b/src/DTOs/Concerns/HasEnvironmentInteractionEvents.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bluezone\DTOs\Concerns;
+
+trait HasEnvironmentInteractionEvents
+{
+    /**
+     * Player take bluezone damage events
+     */
+    public function takeBluezoneDamageEvents(): \Illuminate\Support\Collection
+    {
+        return $this->takeDamageEvents()->filter(fn ($e) => ! isset($e->attacker) && $e->damageTypeCategory == 'Damage_BlueZone');
+    }
+}

--- a/src/DTOs/Concerns/HasPlayerInteractionEvents.php
+++ b/src/DTOs/Concerns/HasPlayerInteractionEvents.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bluezone\DTOs\Concerns;
+
+trait HasPlayerInteractionEvents
+{
+    /**
+     * Cause damage events for a given player account ID
+     */
+    public function causeDamageToPlayer(string $accountId): \Illuminate\Support\Collection
+    {
+        return $this->causeDamageEvents()->filter(fn ($e) => $e->victim->accountId === $accountId);
+    }
+
+    /**
+     * Take damage events for a given player account ID
+     */
+    public function takeDamageFromPlayer(string $accountId): \Illuminate\Support\Collection
+    {
+        return $this->takeDamageEvents()->filter(fn ($e) => isset($e->attacker) && $e->attacker->accountId === $accountId);
+    }
+}

--- a/src/DTOs/Concerns/HasWeaponEvents.php
+++ b/src/DTOs/Concerns/HasWeaponEvents.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bluezone\DTOs\Concerns;
+
+trait HasWeaponEvents
+{
+    /**
+     * Player kill events for a specific weapon
+     */
+    public function killEventsForWeapon(string $weaponCauserName): \Illuminate\Support\Collection
+    {
+        return $this->killEvents()->filter(fn ($e) => isset($e->killerDamageInfo) && $e->killerDamageInfo->causerName == $weaponCauserName);
+    }
+
+    /**
+     * Player cause damage events for a specific weapon
+     */
+    public function causeDamageEventsForWeapon(string $weaponCauserName): \Illuminate\Support\Collection
+    {
+        return $this->causeDamageEvents()->filter(fn ($e) => isset($e->damageCauserName) && $e->damageCauserName == $weaponCauserName);
+    }
+}

--- a/src/Resources/Telemetry/PlayerTelemetry.php
+++ b/src/Resources/Telemetry/PlayerTelemetry.php
@@ -2,12 +2,18 @@
 
 namespace Bluezone\Resources\Telemetry;
 
+use Bluezone\DTOs\Concerns\HasEnvironmentInteractionEvents;
 use Bluezone\DTOs\Concerns\HasPlayerEvents;
+use Bluezone\DTOs\Concerns\HasPlayerInteractionEvents;
+use Bluezone\DTOs\Concerns\HasWeaponEvents;
 use Illuminate\Support\Collection;
 
 class PlayerTelemetry
 {
     use HasPlayerEvents;
+    use HasPlayerInteractionEvents;
+    use HasEnvironmentInteractionEvents;
+    use HasWeaponEvents;
 
     public function __construct(
         protected string $accountId,


### PR DESCRIPTION
* **Added new trait for environment interactions**
Introduced a trait named HasEnvironmentInteractionEvents for handling events related to the environment.
* **Extended HasPlayerEvents trait**
Expanded the existing HasPlayerEvents trait to include methods for filtering events by vehicle, knock, and kill events while using vehicles.
* **Introduced HasPlayerInteractionEvents trait**
Created a new trait called HasPlayerInteractionEvents, featuring two methods - causeDamageToPlayer() and takeDamageFromPlayer(). These methods are utilized in the PlayerTelemetry class.
* **Enhanced HasWeaponEvents trait**
Improved the existing HasWeaponEvents trait by adding a method, killEventForWeapon(). This enables filtering kills based on the weapon type, such as M416, or any other weapon names based on the specific use case. 