### PR TITLE
feat: ability to get many ranked season stats at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .phpunit.cache
+.phpactor.json
 build
 composer.lock
 coverage

--- a/.phpactor.json
+++ b/.phpactor.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "/Applications/Tinkerwell.app/Contents/Resources/phpactor/phpactor.schema.json",
+    "language_server_phpstan.enabled": false
+}

--- a/.phpactor.json
+++ b/.phpactor.json
@@ -1,4 +1,0 @@
-{
-    "$schema": "/Applications/Tinkerwell.app/Contents/Resources/phpactor/phpactor.schema.json",
-    "language_server_phpstan.enabled": false
-}

--- a/src/DTOs/RankedSeasonStats.php
+++ b/src/DTOs/RankedSeasonStats.php
@@ -10,6 +10,8 @@ use Saloon\Contracts\Response;
 class RankedSeasonStats extends PubgDTO
 {
     public function __construct(
+        readonly public string $accountId,
+        readonly public string $seasonId,
         readonly public array $gameModeStats
     ) {
     }
@@ -18,6 +20,6 @@ class RankedSeasonStats extends PubgDTO
     {
         $data = $response->json()['data'];
 
-        return new static($data['attributes']['rankedGameModeStats']);
+        return new static($data['relationships']['player']['data']['id'], $data['relationships']['season']['data']['id'], $data['attributes']['rankedGameModeStats']);
     }
 }

--- a/src/DTOs/RankedSeasonStatsCollection.php
+++ b/src/DTOs/RankedSeasonStatsCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bluezone\DTOs;
+
+use Bluezone\DTOs\RankedSeasonStats;
+use Illuminate\Support\Collection;
+use Saloon\Contracts\DataObjects\WithResponse;
+use Saloon\Contracts\Response;
+
+class RankedSeasonStatsCollection extends PubgDTO
+{
+    public function __construct(
+        readonly public Collection $stats,
+    ) {
+    }
+
+    public static function fromResponse(Response $response): self
+    {
+        return new static(
+            stats: collect($response->json()['data'])->map(fn ($p) => RankedSeasonStats::fromResponse($p))
+        );
+    }
+}

--- a/src/Exceptions/MatchNotFoundException.php
+++ b/src/Exceptions/MatchNotFoundException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bluezone\Exceptions;
+
+use Exception;
+use Throwable;
+
+class MatchNotFoundException extends Exception 
+{
+    public string $matchId;
+
+    public function __construct(string $message, string $matchId)
+    {
+        $this->matchId = $matchId;
+        $this->message = $message;
+
+        parent::__construct($this->formatMessage(), 404);
+    }
+
+    /**
+     * Format the exception message
+     *
+     * @return string
+     */
+    public function formatMessage(): string
+    {
+        return $this->message . ' (' . $this->matchId . ')';
+    }
+}

--- a/src/Requests/Stats/SeasonStatsManyRequest.php
+++ b/src/Requests/Stats/SeasonStatsManyRequest.php
@@ -20,7 +20,7 @@ class SeasonStatsManyRequest extends Request
         protected string $shard,
         protected string $seasonId,
         protected string $gameMode,
-        protected array $playerIds,
+        protected array $accountIds,
     ) {
     }
 
@@ -32,7 +32,7 @@ class SeasonStatsManyRequest extends Request
     protected function defaultQuery(): array
     {
         return [
-            'filter[playerIds]' => implode(',', $this->playerIds),
+            'filter[playerIds]' => implode(',', $this->accountIds),
         ];
     }
 

--- a/src/Resources/MatchResource.php
+++ b/src/Resources/MatchResource.php
@@ -3,7 +3,9 @@
 namespace Bluezone\Resources;
 
 use Bluezone\DTOs\PubgDTO;
+use Bluezone\Exceptions\MatchNotFoundException;
 use Bluezone\Requests\Matches\MatchRequest;
+use Saloon\Exceptions\Request\Statuses\NotFoundException;
 
 class MatchResource extends Resource
 {
@@ -12,9 +14,16 @@ class MatchResource extends Resource
      */
     public function find(string $shard, string $matchId): PubgDTO
     {
-        return $this->send(new MatchRequest(
-            shard: $shard,
-            matchId: $matchId,
-        ));
+        try {
+            return $this->send(new MatchRequest(
+                shard: $shard,
+                matchId: $matchId,
+            ));
+        } catch(NotFoundException $e) {
+            throw new MatchNotFoundException(
+                message: 'This match is not available in the PUBG API.',
+                matchId: $matchId
+            );
+        }
     }
 }

--- a/tests/Feature/PubgApiTest.php
+++ b/tests/Feature/PubgApiTest.php
@@ -6,6 +6,7 @@ use Bluezone\Bluezone;
 use Bluezone\DTOs\Player;
 use Bluezone\DTOs\PlayerMatchStats;
 use Bluezone\DTOs\PubgMatch;
+use Bluezone\DTOs\RankedSeasonStats;
 use Bluezone\DTOs\SeasonStats;
 use Illuminate\Support\Collection;
 
@@ -91,6 +92,16 @@ it('can request many season stats', function () use ($bluezone, $seasonId, $acco
     expect($response->stats->first())->toBeObject()
         ->toHaveProperties(['seasonId', 'accountId', 'gameModeStats']);
 });
+
+it('can request many ranked season stats', function () use ($bluezone, $seasonId, $accountId, $shard) {
+    $response = $bluezone->player()->rankedSeasonStatsMany($shard, $seasonId, [$accountId, $accountId]);
+
+    expect($response->stats->first() instanceof RankedSeasonStats)->toBeTrue();
+
+    expect($response->stats->first())->toBeObject()
+        ->toHaveProperties(['seasonId', 'accountId', 'gameModeStats']);
+});
+
 
 it('can request lifetime stats', function () use ($bluezone, $accountId, $shard) {
     $response = $bluezone->player()->lifetimeStats($shard, $accountId);


### PR DESCRIPTION
Add the ability to search for Ranked Season Stats using an array of account IDs. This will make individual requests to the PUBG API for each account ID. The PUBG API does not have the ability to search for more than one set of ranked stats with a single request.