### PR TITLE
feat: add losses to ranked season stats

### DIFF
--- a/src/DTOs/RankedSeasonStats.php
+++ b/src/DTOs/RankedSeasonStats.php
@@ -20,6 +20,11 @@ class RankedSeasonStats extends PubgDTO
     {
         $data = $response->json()['data'];
 
+        foreach($data['attributes']['rankedGameModeStats'] as $key => $stat)
+        {
+            $data['attributes']['rankedGameModeStats'][$key]['losses'] = $stat['losses'] ?? $stat['roundsPlayed'] - $stat['wins'];
+        }
+
         return new static($data['relationships']['player']['data']['id'], $data['relationships']['season']['data']['id'], $data['attributes']['rankedGameModeStats']);
     }
 }


### PR DESCRIPTION
This specific metric isn't provided by the PUBG API so we'll subtract the amount of wins from the total rounds played to get losses.

If the API ever updates to add losses we'll default to that value.