### PR TITLE
feat: common object for all events, new telemetry events

### DIFF
--- a/src/DTOs/Telemetry.php
+++ b/src/DTOs/Telemetry.php
@@ -42,6 +42,27 @@ class Telemetry
     }
 
     /**
+     * Get all telemetry events that occur during the game
+     *
+     * @return Collection<TelemetryEvents\TelemetryEvent>
+     */
+    public function eventsDuringGame(): Collection
+    {
+        return $this->events()->filter(fn ($e) => $e->common->isGame >= 1);
+    }
+
+    /**
+     * Get all telemetry events that occur during the game and exclude the given events
+     *
+     * @param  array  $excludedEvents
+     * @return Collection<TelemetryEvents\TelemetryEvent>
+     */
+    public function excludeEvents(array $excludedEvents): Collection
+    {
+        return $this->events()->filter(fn ($e) => !in_array(get_class($e), $excludedEvents));
+    }
+
+    /**
      * Get the raw telemetry events from the telemetry file
      */
     public function raw(): Collection
@@ -50,7 +71,7 @@ class Telemetry
     }
 
     /**
-     * Get a Player Telemetry Resource
+     * Get a Match Telemetry Resource
      *
      * @param  string  $ccountId
      */

--- a/src/DTOs/TelemetryEvents/ArmorDestroy.php
+++ b/src/DTOs/TelemetryEvents/ArmorDestroy.php
@@ -6,6 +6,7 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\Concerns\AccessesJsonDictionaries;
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ArmorDestroy extends AbstractEventDTO
@@ -25,6 +26,7 @@ class ArmorDestroy extends AbstractEventDTO
         readonly public string $damageCauserName,
         readonly public Item $item,
         readonly public float $distance,
+        readonly public Common $common,
     ) {
         $this->damageCategoryName = $this->getValueFromJsonFile('telemetry/damageTypeCategory.json', $this->damageTypeCategory);
     }
@@ -40,6 +42,7 @@ class ArmorDestroy extends AbstractEventDTO
             damageCauserName: $data['damageCauserName'],
             item: Item::fromEvent($data['item']),
             distance: $data['distance'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/CarePackageLand.php
+++ b/src/DTOs/TelemetryEvents/CarePackageLand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bluezone\DTOs\TelemetryEvents;
 
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\ItemPackage;
 
 class CarePackageLand extends AbstractEventDTO
@@ -12,6 +13,7 @@ class CarePackageLand extends AbstractEventDTO
 
     public function __construct(
         readonly public ItemPackage $itemPackage,
+        readonly public Common $common,
     ) {
     }
 
@@ -19,6 +21,7 @@ class CarePackageLand extends AbstractEventDTO
     {
         return new static(
             itemPackage: ItemPackage::fromEvent($data['itemPackage']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/CarePackageSpawn.php
+++ b/src/DTOs/TelemetryEvents/CarePackageSpawn.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bluezone\DTOs\TelemetryEvents;
 
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\ItemPackage;
 
 class CarePackageSpawn extends AbstractEventDTO
@@ -12,6 +13,7 @@ class CarePackageSpawn extends AbstractEventDTO
 
     public function __construct(
         readonly public ItemPackage $itemPackage,
+        readonly public Common $common,
     ) {
     }
 
@@ -19,6 +21,7 @@ class CarePackageSpawn extends AbstractEventDTO
     {
         return new static(
             itemPackage: ItemPackage::fromEvent($data['itemPackage']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/CharacterCarry.php
+++ b/src/DTOs/TelemetryEvents/CharacterCarry.php
@@ -6,26 +6,22 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
 use Bluezone\DTOs\TelemetryObjects\Common;
-use Bluezone\DTOs\TelemetryObjects\Item;
 
-class ItemAttach extends AbstractEventDTO
+class CharacterCarry extends AbstractEventDTO
 {
-    public string $type = 'item attach';
+    public string $type = 'player revive';
 
     public function __construct(
         readonly public Character $character,
-        readonly public Item $parentItem,
-        readonly public Item $childItem,
+        readonly public string $carryState,
         readonly public Common $common,
-    ) {
-    }
+    ) {}
 
     public static function fromEvent(array $data): self
     {
         return new static(
             character: Character::fromEvent($data['character']),
-            parentItem: Item::fromEvent($data['parentItem']),
-            childItem: Item::fromEvent($data['childItem']),
+            carryState: $data['carryState'],
             common: Common::fromEvent($data['common']),
         );
     }

--- a/src/DTOs/TelemetryEvents/EmPickupLiftOff.php
+++ b/src/DTOs/TelemetryEvents/EmPickupLiftOff.php
@@ -6,24 +6,23 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
 use Bluezone\DTOs\TelemetryObjects\Common;
-use Bluezone\DTOs\TelemetryObjects\Item;
+use Illuminate\Support\Collection;
 
-class ItemPickup extends AbstractEventDTO
+class EmPickupLiftOff extends AbstractEventDTO
 {
-    public string $type = 'item pickup';
+    public string $type = 'emergency pickup lift off';
 
     public function __construct(
-        readonly public Character $character,
-        readonly public Item $item,
+        readonly public Character $instigator,
+        readonly public Collection $riders,
         readonly public Common $common,
-    ) {
-    }
+    ) {}
 
     public static function fromEvent(array $data): self
     {
         return new static(
-            character: Character::fromEvent($data['character']),
-            item: Item::fromEvent($data['item']),
+            instigator: Character::fromEvent($data['instigator']),
+            riders: collect($data['riders'])->map(fn($rider) => Character::fromEvent($rider)),
             common: Common::fromEvent($data['common']),
         );
     }

--- a/src/DTOs/TelemetryEvents/EventFactory.php
+++ b/src/DTOs/TelemetryEvents/EventFactory.php
@@ -18,6 +18,10 @@ class EventFactory
                 return CarePackageLand::fromEvent($data);
             case 'LogCarePackageSpawn':
                 return CarePackageSpawn::fromEvent($data);
+            case 'LogCharacterCarry':
+                return CharacterCarry::fromEvent($data);
+            case 'LogEmPickupLiftOff':
+                return EmPickupLiftOff::fromEvent($data);
             case 'LogGameStatePeriodic':
                 return GameStatePeriodic::fromEvent($data);
             case 'LogHeal':
@@ -32,12 +36,14 @@ class EventFactory
                 return ItemEquip::fromEvent($data);
             case 'LogItemPickup':
                 return ItemPickup::fromEvent($data);
-            case 'LogItemPickupFromCarePackage':
+            case 'LogItemPickupFromCarepackage':
                 return ItemPickupFromCarePackage::fromEvent($data);
             case 'LogItemPickupFromCustomPackage':
                 return ItemPickupFromCustomPackage::fromEvent($data);
             case 'LogItemPickupFromLootBox':
                 return ItemPickupFromLootBox::fromEvent($data);
+            case 'LogItemPutToVehicleTrunk':
+                return ItemPutToVehicleTrunk::fromEvent($data);
             case 'LogItemUnequip':
                 return ItemUnequip::fromEvent($data);
             case 'LogItemUse':
@@ -70,6 +76,8 @@ class EventFactory
                 return PlayerMakeGroggy::fromEvent($data);
             case 'LogPlayerPosition':
                 return PlayerPosition::fromEvent($data);
+            case 'LogPlayerRevive':
+                return PlayerRevive::fromEvent($data);
             case 'LogPlayerTakeDamage':
                 return PlayerTakeDamage::fromEvent($data);
             case 'LogPlayerUseThrowable':
@@ -93,6 +101,7 @@ class EventFactory
             case 'LogWheelDestroy':
                 return WheelDestroy::fromEvent($data);
             default:
+                // dd($data);
                 return $data;
         }
     }

--- a/src/DTOs/TelemetryEvents/GameStatePeriodic.php
+++ b/src/DTOs/TelemetryEvents/GameStatePeriodic.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bluezone\DTOs\TelemetryEvents;
 
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\GameState;
 
 class GameStatePeriodic extends AbstractEventDTO
@@ -12,6 +13,7 @@ class GameStatePeriodic extends AbstractEventDTO
 
     public function __construct(
         readonly public GameState $gameState,
+        readonly public Common $common,
     ) {
     }
 
@@ -19,6 +21,7 @@ class GameStatePeriodic extends AbstractEventDTO
     {
         return new static(
             gameState: GameState::fromEvent($data['gameState']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/Heal.php
+++ b/src/DTOs/TelemetryEvents/Heal.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class Heal extends AbstractEventDTO
@@ -15,6 +16,7 @@ class Heal extends AbstractEventDTO
         readonly public Character $character,
         readonly public Item $item,
         readonly public float $healAmount,
+        readonly public Common $common,
     ) {
     }
 
@@ -24,6 +26,7 @@ class Heal extends AbstractEventDTO
             character: Character::fromEvent($data['character']),
             item: Item::fromEvent($data['item']),
             healAmount: isset($data['healamount']) ? $data['healamount'] : (isset($data['healAmount']) ? $data['healAmount'] : 0),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ItemDetach.php
+++ b/src/DTOs/TelemetryEvents/ItemDetach.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ItemDetach extends AbstractEventDTO
@@ -15,6 +16,7 @@ class ItemDetach extends AbstractEventDTO
         readonly public Character $character,
         readonly public Item $parentItem,
         readonly public Item $childItem,
+        readonly public Common $common,
     ) {
     }
 
@@ -24,6 +26,7 @@ class ItemDetach extends AbstractEventDTO
             character: Character::fromEvent($data['character']),
             parentItem: Item::fromEvent($data['parentItem']),
             childItem: Item::fromEvent($data['childItem']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ItemDrop.php
+++ b/src/DTOs/TelemetryEvents/ItemDrop.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ItemDrop extends AbstractEventDTO
@@ -14,6 +15,7 @@ class ItemDrop extends AbstractEventDTO
     public function __construct(
         readonly public Character $character,
         readonly public Item $item,
+        readonly public Common $common,
     ) {
     }
 
@@ -22,6 +24,7 @@ class ItemDrop extends AbstractEventDTO
         return new static(
             character: Character::fromEvent($data['character']),
             item: Item::fromEvent($data['item']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ItemEquip.php
+++ b/src/DTOs/TelemetryEvents/ItemEquip.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ItemEquip extends AbstractEventDTO
@@ -14,6 +15,7 @@ class ItemEquip extends AbstractEventDTO
     public function __construct(
         readonly public Character $character,
         readonly public Item $item,
+        readonly public Common $common,
     ) {
     }
 
@@ -22,6 +24,7 @@ class ItemEquip extends AbstractEventDTO
         return new static(
             character: Character::fromEvent($data['character']),
             item: Item::fromEvent($data['item']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ItemPickupFromCarePackage.php
+++ b/src/DTOs/TelemetryEvents/ItemPickupFromCarePackage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ItemPickupFromCarePackage extends AbstractEventDTO
@@ -15,6 +16,7 @@ class ItemPickupFromCarePackage extends AbstractEventDTO
         readonly public Character $character,
         readonly public Item $item,
         readonly public float $carePackageUniqueId,
+        readonly public Common $common,
     ) {
     }
 
@@ -24,6 +26,7 @@ class ItemPickupFromCarePackage extends AbstractEventDTO
             character: Character::fromEvent($data['character']),
             item: Item::fromEvent($data['item']),
             carePackageUniqueId: $data['carePackageUniqueId'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ItemPickupFromLootBox.php
+++ b/src/DTOs/TelemetryEvents/ItemPickupFromLootBox.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ItemPickupFromLootBox extends AbstractEventDTO
@@ -16,6 +17,7 @@ class ItemPickupFromLootBox extends AbstractEventDTO
         readonly public Item $item,
         readonly public int $ownerTeamId,
         readonly public string $creatorAccountId,
+        readonly public Common $common,
     ) {
     }
 
@@ -26,6 +28,7 @@ class ItemPickupFromLootBox extends AbstractEventDTO
             item: Item::fromEvent($data['item']),
             ownerTeamId: $data['ownerTeamId'],
             creatorAccountId: $data['creatorAccountId'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ItemPutToVehicleTrunk.php
+++ b/src/DTOs/TelemetryEvents/ItemPutToVehicleTrunk.php
@@ -7,25 +7,25 @@ namespace Bluezone\DTOs\TelemetryEvents;
 use Bluezone\DTOs\TelemetryObjects\Character;
 use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
+use Bluezone\DTOs\TelemetryObjects\Vehicle;
 
-class ItemAttach extends AbstractEventDTO
+class ItemPutToVehicleTrunk extends AbstractEventDTO
 {
-    public string $type = 'item attach';
+    public string $type = 'player revive';
 
     public function __construct(
         readonly public Character $character,
-        readonly public Item $parentItem,
-        readonly public Item $childItem,
+        readonly public Vehicle $vehicle,
+        readonly public Item $item,
         readonly public Common $common,
-    ) {
-    }
+    ) {}
 
     public static function fromEvent(array $data): self
     {
         return new static(
             character: Character::fromEvent($data['character']),
-            parentItem: Item::fromEvent($data['parentItem']),
-            childItem: Item::fromEvent($data['childItem']),
+            vehicle: Vehicle::fromEvent($data['vehicle']),
+            item: Item::fromEvent($data['item']),
             common: Common::fromEvent($data['common']),
         );
     }

--- a/src/DTOs/TelemetryEvents/ItemUnequip.php
+++ b/src/DTOs/TelemetryEvents/ItemUnequip.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ItemUnequip extends AbstractEventDTO
@@ -14,6 +15,7 @@ class ItemUnequip extends AbstractEventDTO
     public function __construct(
         readonly public Character $character,
         readonly public Item $item,
+        readonly public Common $common,
     ) {
     }
 
@@ -22,6 +24,7 @@ class ItemUnequip extends AbstractEventDTO
         return new static(
             character: Character::fromEvent($data['character']),
             item: Item::fromEvent($data['item']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ItemUse.php
+++ b/src/DTOs/TelemetryEvents/ItemUse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class ItemUse extends AbstractEventDTO
@@ -14,6 +15,7 @@ class ItemUse extends AbstractEventDTO
     public function __construct(
         readonly public Character $character,
         readonly public Item $item,
+        readonly public Common $common,
     ) {
     }
 
@@ -22,6 +24,7 @@ class ItemUse extends AbstractEventDTO
         return new static(
             character: Character::fromEvent($data['character']),
             item: Item::fromEvent($data['item']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/MatchDefinition.php
+++ b/src/DTOs/TelemetryEvents/MatchDefinition.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bluezone\DTOs\TelemetryEvents;
 
+use Bluezone\DTOs\TelemetryObjects\Common;
+
 class MatchDefinition extends AbstractEventDTO
 {
     public string $type = 'match definition';
@@ -12,6 +14,7 @@ class MatchDefinition extends AbstractEventDTO
         readonly public string $matchId,
         readonly public string|null $pingQuality,
         readonly public string|null $seasonState,
+        readonly public Common $common,
     ) {
     }
 
@@ -21,6 +24,7 @@ class MatchDefinition extends AbstractEventDTO
             matchId: $data['MatchId'],
             pingQuality: $data['PingQuality'] ?? null,
             seasonState: $data['SeasonState'] ?? null,
+            common: Common::fromEvent(['isGame' => 0]),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/MatchEnd.php
+++ b/src/DTOs/TelemetryEvents/MatchEnd.php
@@ -6,6 +6,7 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\AllWeaponStats;
 use Bluezone\DTOs\TelemetryObjects\CharacterWrapper;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\GameResultOnFinished;
 
 class MatchEnd extends AbstractEventDTO
@@ -16,6 +17,7 @@ class MatchEnd extends AbstractEventDTO
         readonly public array $characters,
         readonly public GameResultOnFinished $gameResultOnFinished,
         readonly public array $allWeaponStats,
+        readonly public Common $common,
     ) {
     }
 
@@ -25,6 +27,7 @@ class MatchEnd extends AbstractEventDTO
             characters: array_map(fn ($character) => CharacterWrapper::fromEvent($character), $data['characters']),
             gameResultOnFinished: GameResultOnFinished::fromEvent($data['gameResultOnFinished']),
             allWeaponStats: array_map(fn ($weaponStats) => AllWeaponStats::fromEvent($weaponStats), $data['allWeaponStats']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/MatchStart.php
+++ b/src/DTOs/TelemetryEvents/MatchStart.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\CharacterWrapper;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class MatchStart extends AbstractEventDTO
 {
@@ -19,6 +20,7 @@ class MatchStart extends AbstractEventDTO
         readonly public bool $isCustomGame,
         readonly public bool $isEventMode,
         readonly public string $blueZoneCustomOptions,
+        readonly public Common $common,
     ) {
     }
 
@@ -33,6 +35,7 @@ class MatchStart extends AbstractEventDTO
             isCustomGame: $data['isCustomGame'],
             isEventMode: $data['isEventMode'],
             blueZoneCustomOptions: $data['blueZoneCustomOptions'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ObjectDestroy.php
+++ b/src/DTOs/TelemetryEvents/ObjectDestroy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Location;
 
 class ObjectDestroy extends AbstractEventDTO
@@ -15,6 +16,7 @@ class ObjectDestroy extends AbstractEventDTO
         readonly public Character $character,
         readonly public string $objectType,
         readonly public Location|null $objectLocation,
+        readonly public Common $common,
     ) {
     }
 
@@ -24,6 +26,7 @@ class ObjectDestroy extends AbstractEventDTO
             character: Character::fromEvent($data['character']),
             objectType: $data['objectType'],
             objectLocation: isset($data['objectLocation']) ? Location::fromEvent($data['objectLocation']) : null,
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ObjectInteraction.php
+++ b/src/DTOs/TelemetryEvents/ObjectInteraction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Location;
 
 class ObjectInteraction extends AbstractEventDTO
@@ -15,6 +16,7 @@ class ObjectInteraction extends AbstractEventDTO
         readonly public Character $character,
         readonly public string $objectType,
         readonly public Location|null $objectLocation,
+        readonly public Common $common,
     ) {
     }
 
@@ -24,6 +26,7 @@ class ObjectInteraction extends AbstractEventDTO
             character: Character::fromEvent($data['character']),
             objectType: $data['objectType'],
             objectLocation: isset($data['objectLocation']) ? Location::fromEvent($data['objectLocation']) : null,
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/ParachuteLanding.php
+++ b/src/DTOs/TelemetryEvents/ParachuteLanding.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class ParachuteLanding extends AbstractEventDTO
 {
@@ -13,6 +14,7 @@ class ParachuteLanding extends AbstractEventDTO
     public function __construct(
         readonly public Character $character,
         readonly public float $distance,
+        readonly public Common $common,
     ) {
     }
 
@@ -21,6 +23,7 @@ class ParachuteLanding extends AbstractEventDTO
         return new static(
             character: Character::fromEvent($data['character']),
             distance: $data['distance'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/PlayerAttack.php
+++ b/src/DTOs/TelemetryEvents/PlayerAttack.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 use Bluezone\DTOs\TelemetryObjects\Vehicle;
 
@@ -19,6 +20,7 @@ class PlayerAttack extends AbstractEventDTO
         readonly public string $attackType,
         readonly public Item $weapon,
         readonly public Vehicle|null $vehicle,
+        readonly public Common $common,
     ) {
     }
 
@@ -31,6 +33,7 @@ class PlayerAttack extends AbstractEventDTO
             attackType: $data['attackType'],
             weapon: Item::fromEvent($data['weapon']),
             vehicle: $data['vehicle'] ? Vehicle::fromEvent($data['vehicle']) : null,
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/PlayerCreate.php
+++ b/src/DTOs/TelemetryEvents/PlayerCreate.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class PlayerCreate extends AbstractEventDTO
 {
@@ -12,6 +13,7 @@ class PlayerCreate extends AbstractEventDTO
 
     public function __construct(
         readonly public Character $character,
+        readonly public Common $common,
     ) {
     }
 
@@ -19,6 +21,7 @@ class PlayerCreate extends AbstractEventDTO
     {
         return new static(
             character: Character::fromEvent($data['character']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/PlayerKillV2.php
+++ b/src/DTOs/TelemetryEvents/PlayerKillV2.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\DamageInfo;
 use Bluezone\DTOs\TelemetryObjects\GameResult;
 
@@ -28,6 +29,7 @@ class PlayerKillV2 extends AbstractEventDTO
         readonly public array $assists_AccountId,
         readonly public array $teamKillers_AccountId,
         readonly public bool $isSuicide,
+        readonly public Common $common,
     ) {
     }
 
@@ -49,6 +51,7 @@ class PlayerKillV2 extends AbstractEventDTO
             assists_AccountId: $data['assists_AccountId'],
             teamKillers_AccountId: $data['teamKillers_AccountId'],
             isSuicide: $data['isSuicide'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/PlayerMakeGroggy.php
+++ b/src/DTOs/TelemetryEvents/PlayerMakeGroggy.php
@@ -6,6 +6,7 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\Concerns\AccessesJsonDictionaries;
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class PlayerMakeGroggy extends AbstractEventDTO
 {
@@ -29,6 +30,7 @@ class PlayerMakeGroggy extends AbstractEventDTO
         readonly public bool $isAttackerInVehicle,
         readonly public int $dBNOId,
         readonly public bool $isThroughPenetrableWall,
+        readonly public Common $common,
     ) {
         $this->damageCategoryName = $this->getValueFromJsonFile('telemetry/damageTypeCategory.json', $this->damageTypeCategory);
     }
@@ -49,6 +51,7 @@ class PlayerMakeGroggy extends AbstractEventDTO
             isAttackerInVehicle: $data['isAttackerInVehicle'],
             dBNOId: $data['dBNOId'],
             isThroughPenetrableWall: $data['isThroughPenetrableWall'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/PlayerPosition.php
+++ b/src/DTOs/TelemetryEvents/PlayerPosition.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Vehicle;
 
 class PlayerPosition extends AbstractEventDTO
@@ -16,16 +17,19 @@ class PlayerPosition extends AbstractEventDTO
         readonly public Vehicle|null $vehicle,
         readonly public float $elapsedTime,
         readonly public int $numAlivePlayers,
+        readonly public Common $common,
     ) {
     }
 
     public static function fromEvent(array $data): self
     {
+        // dd($data);
         return new static(
             character: Character::fromEvent($data['character']),
             vehicle: $data['vehicle'] ? Vehicle::fromEvent($data['vehicle']) : null,
             elapsedTime: $data['elapsedTime'],
             numAlivePlayers: $data['numAlivePlayers'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/PlayerRevive.php
+++ b/src/DTOs/TelemetryEvents/PlayerRevive.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bluezone\DTOs\TelemetryEvents;
+
+use Bluezone\DTOs\Concerns\AccessesJsonDictionaries;
+use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
+
+class PlayerRevive extends AbstractEventDTO
+{
+    public string $type = 'player revive';
+
+    public function __construct(
+        readonly public Character|null $reviver,
+        readonly public Character $victim,
+        readonly public int $dBNOId,
+        readonly public Common $common,
+    ) {}
+
+    public static function fromEvent(array $data): self
+    {
+        return new static(
+            reviver: $data['reviver'] ? Character::fromEvent($data['reviver']) : null,
+            victim: Character::fromEvent($data['victim']),
+            dBNOId: $data['dBNOId'],
+            common: Common::fromEvent($data['common']),
+        );
+    }
+}

--- a/src/DTOs/TelemetryEvents/PlayerTakeDamage.php
+++ b/src/DTOs/TelemetryEvents/PlayerTakeDamage.php
@@ -6,6 +6,7 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\Concerns\AccessesJsonDictionaries;
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class PlayerTakeDamage extends AbstractEventDTO
 {
@@ -24,6 +25,7 @@ class PlayerTakeDamage extends AbstractEventDTO
         readonly public string $damageCauserName,
         readonly public float $damage,
         readonly public bool $isThroughPenetrableWall,
+        readonly public Common $common,
     ) {
         $this->damageCategoryName = $this->getValueFromJsonFile('telemetry/damageTypeCategory.json', $this->damageTypeCategory);
     }
@@ -39,6 +41,7 @@ class PlayerTakeDamage extends AbstractEventDTO
             damageCauserName: $data['damageCauserName'],
             damage: $data['damage'],
             isThroughPenetrableWall: $data['isThroughPenetrableWall'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/PlayerUseThrowable.php
+++ b/src/DTOs/TelemetryEvents/PlayerUseThrowable.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Item;
 
 class PlayerUseThrowable extends AbstractEventDTO
@@ -17,6 +18,7 @@ class PlayerUseThrowable extends AbstractEventDTO
         readonly public Character $attacker,
         readonly public string $attackType,
         readonly public Item $weapon,
+        readonly public Common $common,
     ) {
     }
 
@@ -28,6 +30,7 @@ class PlayerUseThrowable extends AbstractEventDTO
             attacker: Character::fromEvent($data['attacker']),
             attackType: $data['attackType'],
             weapon: Item::fromEvent($data['weapon']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/SwimEnd.php
+++ b/src/DTOs/TelemetryEvents/SwimEnd.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class SwimEnd extends AbstractEventDTO
 {
@@ -14,6 +15,7 @@ class SwimEnd extends AbstractEventDTO
         readonly public Character $character,
         readonly public float $swimDistance,
         readonly public float $maxSwimDepthOfWater,
+        readonly public Common $common,
     ) {
     }
 
@@ -23,6 +25,7 @@ class SwimEnd extends AbstractEventDTO
             character: Character::fromEvent($data['character']),
             swimDistance: $data['swimDistance'],
             maxSwimDepthOfWater: $data['maxSwimDepthOfWater'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/SwimStart.php
+++ b/src/DTOs/TelemetryEvents/SwimStart.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class SwimStart extends AbstractEventDTO
 {
@@ -12,6 +13,7 @@ class SwimStart extends AbstractEventDTO
 
     public function __construct(
         readonly public Character $character,
+        readonly public Common $common,
     ) {
     }
 
@@ -19,6 +21,7 @@ class SwimStart extends AbstractEventDTO
     {
         return new static(
             character: Character::fromEvent($data['character']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/VaultStart.php
+++ b/src/DTOs/TelemetryEvents/VaultStart.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class VaultStart extends AbstractEventDTO
 {
@@ -13,6 +14,7 @@ class VaultStart extends AbstractEventDTO
     public function __construct(
         readonly public Character $character,
         readonly public bool $isLedgeGrab,
+        readonly public Common $common,
     ) {
     }
 
@@ -21,6 +23,7 @@ class VaultStart extends AbstractEventDTO
         return new static(
             character: Character::fromEvent($data['character']),
             isLedgeGrab: $data['isLedgeGrab'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/VehicleDamage.php
+++ b/src/DTOs/TelemetryEvents/VehicleDamage.php
@@ -6,6 +6,7 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\Concerns\AccessesJsonDictionaries;
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Vehicle;
 
 class VehicleDamage extends AbstractEventDTO
@@ -24,6 +25,7 @@ class VehicleDamage extends AbstractEventDTO
         readonly public string $damageCauserName,
         readonly public float $damage,
         readonly public float $distance,
+        readonly public Common $common,
     ) {
         $this->damageCategoryName = $this->getValueFromJsonFile('telemetry/damageTypeCategory.json', $this->damageTypeCategory);
     }
@@ -38,6 +40,7 @@ class VehicleDamage extends AbstractEventDTO
             damageCauserName: $data['damageCauserName'],
             damage: $data['damage'],
             distance: $data['distance'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/VehicleLeave.php
+++ b/src/DTOs/TelemetryEvents/VehicleLeave.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Vehicle;
 
 class VehicleLeave extends AbstractEventDTO
@@ -18,6 +19,7 @@ class VehicleLeave extends AbstractEventDTO
         readonly public int $seatIndex,
         readonly public float $maxSpeed,
         readonly public array $fellowPassengers,
+        readonly public Common $common,
     ) {
     }
 
@@ -30,6 +32,7 @@ class VehicleLeave extends AbstractEventDTO
             seatIndex: $data['seatIndex'],
             maxSpeed: $data['maxSpeed'],
             fellowPassengers: array_map(fn ($passenger) => Character::fromEvent($passenger), $data['fellowPassengers']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/VehicleRide.php
+++ b/src/DTOs/TelemetryEvents/VehicleRide.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Vehicle;
 
 class VehicleRide extends AbstractEventDTO
@@ -16,6 +17,7 @@ class VehicleRide extends AbstractEventDTO
         readonly public Vehicle $vehicle,
         readonly public int $seatIndex,
         readonly public array $fellowPassengers,
+        readonly public Common $common,
     ) {
     }
 
@@ -26,6 +28,7 @@ class VehicleRide extends AbstractEventDTO
             vehicle: Vehicle::fromEvent($data['vehicle']),
             seatIndex: $data['seatIndex'],
             fellowPassengers: array_map(fn ($passenger) => Character::fromEvent($passenger), $data['fellowPassengers']),
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/WeaponFireCount.php
+++ b/src/DTOs/TelemetryEvents/WeaponFireCount.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 
 class WeaponFireCount extends AbstractEventDTO
 {
@@ -14,6 +15,7 @@ class WeaponFireCount extends AbstractEventDTO
         readonly public Character $character,
         readonly public string $weaponId,
         readonly public int $fireCount,
+        readonly public Common $common,
     ) {
     }
 
@@ -23,6 +25,7 @@ class WeaponFireCount extends AbstractEventDTO
             character: Character::fromEvent($data['character']),
             weaponId: $data['weaponId'],
             fireCount: $data['fireCount'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryEvents/WheelDestroy.php
+++ b/src/DTOs/TelemetryEvents/WheelDestroy.php
@@ -6,6 +6,7 @@ namespace Bluezone\DTOs\TelemetryEvents;
 
 use Bluezone\DTOs\Concerns\AccessesJsonDictionaries;
 use Bluezone\DTOs\TelemetryObjects\Character;
+use Bluezone\DTOs\TelemetryObjects\Common;
 use Bluezone\DTOs\TelemetryObjects\Vehicle;
 
 class WheelDestroy extends AbstractEventDTO
@@ -22,6 +23,7 @@ class WheelDestroy extends AbstractEventDTO
         readonly public Vehicle $vehicle,
         readonly public string $damageTypeCategory,
         readonly public string $damageCauserName,
+        readonly public Common $common,
     ) {
         $this->damageCategoryName = $this->getValueFromJsonFile('telemetry/damageTypeCategory.json', $this->damageTypeCategory);
     }
@@ -34,6 +36,7 @@ class WheelDestroy extends AbstractEventDTO
             vehicle: Vehicle::fromEvent($data['vehicle']),
             damageTypeCategory: $data['damageTypeCategory'],
             damageCauserName: $data['damageCauserName'],
+            common: Common::fromEvent($data['common']),
         );
     }
 }

--- a/src/DTOs/TelemetryObjects/Common.php
+++ b/src/DTOs/TelemetryObjects/Common.php
@@ -6,9 +6,18 @@ namespace Bluezone\DTOs\TelemetryObjects;
 
 class Common
 {
+    public string $name;
+    public bool $isPreGameLobby;
+    public bool $planeIsFlying;
+    public bool $circlesHaveStarted;
+
     public function __construct(
         readonly public float $isGame,
     ) {
+        $this->name = $this->phaseName();
+        $this->isPreGameLobby = $this->isGame < 0.1;
+        $this->planeIsFlying = $this->isGame >= 0.1 && $this->isGame < 0.5;
+        $this->circlesHaveStarted = $this->isGame >= 1;
     }
 
     public static function fromEvent(array $data): self
@@ -20,7 +29,7 @@ class Common
     {
         return match (true) {
             $this->isGame < 0.1 => 'Before lift off',
-            $this->isGame >= 0.1 && $this->isGame < 0.5 => 'On airplane',
+            $this->isGame >= 0.1 && $this->isGame < 0.5 => 'Airplane in flight',
             $this->isGame >= 0.5 && $this->isGame < 1.0 => 'Before 1st zone',
             $this->isGame >= 1.0 && $this->isGame < 1.5 => '1st zone appears',
             $this->isGame >= 1.5 && $this->isGame < 2.0 => '1st bluezone shrinks',


### PR DESCRIPTION
This PR adds additional telemetry events for :
- Character Carry
- Emergency Pickup Lift Off
- Item Put To Vehicle Trunk
- Player Revive

This also adds a game Common object to all events

Common telemetry object has been updated with bool parameters for various game state